### PR TITLE
fix: add semantic-release dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "path-browserify": "^1.0.1",
     "prettier": "^3.4.2",
     "process": "^0.11.10",
+    "semantic-release": "^24.2.0",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "ts-loader": "^9.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       process:
         specifier: ^0.11.10
         version: 0.11.10
+      semantic-release:
+        specifier: ^24.2.0
+        version: 24.2.0(typescript@5.7.2)
       stream-browserify:
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
Add semantic-release as a devDependency to fix CI release job failures.

- Adds semantic-release package to devDependencies
- Fixes 'semantic-release: not found' error in CI

Link to Devin run: https://app.devin.ai/sessions/c4fc24b6dd6749a6aa8c355d316252fb